### PR TITLE
fix: protobuf crashing on M1 macOS

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ setup_requires =
     setuptools>=51.1.1
     wheel>=0.36.2
 install_requires =
+    protobuf==3.19.4  # limit until https://github.com/protocolbuffers/protobuf/issues/10571 is fixed
     grpcio==1.48.2
     grpcio-tools==1.48.2
     async-timeout~=4.0.0


### PR DESCRIPTION
This PR pins protobuf version to 3.19.4 (ref: protocolbuffers/protobuf#10571).