### PR TITLE
fix: Fix lock TTL

### DIFF
--- a/src/etcetra/client.py
+++ b/src/etcetra/client.py
@@ -1591,6 +1591,12 @@ class EtcdLockManager:
                     ),
                 )
             self._lock_id = response.key.decode(self.encoding)
+            if self._keepalive_task is not None:
+                self._keepalive_task.cancel()
+                try:
+                    await self._keepalive_task
+                except asyncio.CancelledError:
+                    pass
         except asyncio.TimeoutError:
             if self._keepalive_task is not None:
                 self._keepalive_task.cancel()

--- a/src/etcetra/client.py
+++ b/src/etcetra/client.py
@@ -1591,19 +1591,7 @@ class EtcdLockManager:
                     ),
                 )
             self._lock_id = response.key.decode(self.encoding)
-            if self._keepalive_task is not None:
-                self._keepalive_task.cancel()
-                try:
-                    await self._keepalive_task
-                except asyncio.CancelledError:
-                    pass
         except asyncio.TimeoutError:
-            if self._keepalive_task is not None:
-                self._keepalive_task.cancel()
-                try:
-                    await self._keepalive_task
-                except asyncio.CancelledError:
-                    pass
             if self._lease_id is not None:
                 try:
                     await communicator.revoke_lease(self._lease_id)
@@ -1611,14 +1599,13 @@ class EtcdLockManager:
                     if e.code() != grpc.StatusCode.NOT_FOUND:
                         raise e
             raise
-        except:
+        finally:
             if self._keepalive_task is not None:
                 self._keepalive_task.cancel()
                 try:
                     await self._keepalive_task
                 except asyncio.CancelledError:
                     pass
-            raise
 
     async def __aexit__(self, exc_type, exc, tb) -> Optional[bool]:
         """


### PR DESCRIPTION
In #8, lease keepalive task was added. The intent was to preserve the lease between lock request and lock acquisition. By mistake, the lease keepalive continued after the lock acquisition, making the lock TTL ineffective. Therefore, cancel the lease keepalive task when the lock is acquired.

Also add a new test. In `test_lock_ttl_2`, lock with TTL expires at T+4 without keepalive, T+6 with this PR, and unlocks without expiration at T+8 before this PR. 