### PR TITLE
Add support for revision in PUT response

### DIFF
--- a/src/etcetra/client.py
+++ b/src/etcetra/client.py
@@ -1442,9 +1442,8 @@ class EtcdTransaction:
         for response in result.responses:
             response_type = response.WhichOneof('response')
             if response_type == 'response_put':
-                # nb: Venu Added support for put revision
                 ret.append({
-                    "revision": response.response_put.header.revision
+                    "revision": response.response_put.header.revision,
                 })
             elif response_type == 'response_range':
                 ret.append({

--- a/src/etcetra/client.py
+++ b/src/etcetra/client.py
@@ -1442,7 +1442,10 @@ class EtcdTransaction:
         for response in result.responses:
             response_type = response.WhichOneof('response')
             if response_type == 'response_put':
-                ret.append(None)  # TODO: Handle put response
+                # nb: Venu Added support for put revision
+                ret.append({
+                    "revision": response.response_put.header.revision
+                })
             elif response_type == 'response_range':
                 ret.append({
                     x.key.decode(encoding): x.value.decode(encoding)

--- a/tests/test_txn.py
+++ b/tests/test_txn.py
@@ -16,7 +16,7 @@ async def test_txn(etcd: EtcdClient):
 
         results = await communicator.txn(_txn)
         assert results[0] == {'/test/asd': '123'}
-        assert results[1] is None
+        assert results[1] is not None and results[1].get("revision") is not None
         assert results[2] == {'/test/foo': 'bar'}
 
         assert (await communicator.get('/test/qwe')) == 'rty'


### PR DESCRIPTION
This PR add revision id in the PUT response, so it can be used in transactions (comparekey)!