### PR TITLE
setup: Update dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ lint =
     flake8>=4.0.1
     flake8-commas>=2.1
 typecheck =
-    mypy>=0.930
+    mypy>=1.4.1
     types-protobuf
     types-setuptools
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,9 +32,9 @@ setup_requires =
     setuptools>=51.1.1
     wheel>=0.36.2
 install_requires =
-    protobuf~=4.21.6
-    grpcio==1.50.0
-    grpcio-tools==1.50.0
+    protobuf~=4.23.4
+    grpcio==1.56.2
+    grpcio-tools==1.56.2
     async-timeout~=4.0.0
 zip_safe = false
 include_package_data = true


### PR DESCRIPTION
grpcio (1.50.0 -> 1.56.2)
protobuf (4.21.6 -> 4.23.4)
mypy (0.930 -> 1.4.1)

- The latest grpcio release now provides Python 3.11 linux aarch64
  wheels, which simplifies installation in VM-based dev setups.
