### PR TITLE
Fix range_end calculation

### DIFF
--- a/src/etcetra/client.py
+++ b/src/etcetra/client.py
@@ -362,10 +362,7 @@ class EtcdRequestGenerator:
         encoding='utf-8',
     ):
         encoded_key = key.encode(encoding)
-        if key[-1] == '/' and len(key) >= 2:
-            range_end = encoded_key[:-2] + bytes([encoded_key[-2] + 1]) + b'/'
-        else:
-            range_end = encoded_key[:-1] + bytes([encoded_key[-1] + 1])
+        range_end = increment_last_byte(encoded_key, encoding)
         return rpc_pb2.RangeRequest(
             key=encoded_key,
             range_end=range_end,
@@ -408,10 +405,7 @@ class EtcdRequestGenerator:
     ):
         # TODO: Implement prev_kv response
         encoded_key = key.encode(encoding)
-        if key[-1] == '/' and len(key) >= 2:
-            range_end = encoded_key[:-2] + bytes([encoded_key[-2] + 1]) + b'/'
-        else:
-            range_end = encoded_key[:-1] + bytes([encoded_key[-1] + 1])
+        range_end = increment_last_byte(encoded_key, encoding)
         return rpc_pb2.DeleteRangeRequest(
             key=encoded_key,
             range_end=range_end,
@@ -461,10 +455,7 @@ class EtcdRequestGenerator:
         encoding='utf-8',
     ):
         encoded_key = key.encode(encoding)
-        if key[-1] == '/' and len(key) >= 2:
-            range_end = encoded_key[:-2] + bytes([encoded_key[-2] + 1]) + b'/'
-        else:
-            range_end = encoded_key[:-1] + bytes([encoded_key[-1] + 1])
+        range_end = increment_last_byte(encoded_key, encoding)
         return rpc_pb2.RangeRequest(
             key=encoded_key,
             range_end=range_end,
@@ -1309,10 +1300,7 @@ class EtcdCommunicator:
             encoding = self.encoding
 
         encoded_key = key.encode(encoding)
-        if key[-1] == '/' and len(key) >= 2:
-            range_end = encoded_key[:-2] + bytes([encoded_key[-2] + 1]) + b'/'
-        else:
-            range_end = encoded_key[:-1] + bytes([encoded_key[-1] + 1])
+        range_end = increment_last_byte(encoded_key, encoding)
         return self._watch_impl(
             key.encode(encoding), encoding,
             ready_event=ready_event, filters=filters, prev_kv=prev_kv,
@@ -1671,3 +1659,18 @@ class EtcdLockManager:
         self._lock_id = None
         self._lease_id = None
         return False
+
+
+def increment_last_byte(key, encoding="utf-8"):
+    if type(key) is str:
+        byte_string = key.encode(encoding)
+    else:
+        byte_string = key
+
+    s = bytearray(byte_string)
+    for i in range(len(s) - 1, -1, -1):
+        if s[i] < 0xff:
+            s[i] += 1
+            return bytes(s[:i + 1])
+    else:
+        return b'\x00'

--- a/src/etcetra/client.py
+++ b/src/etcetra/client.py
@@ -362,7 +362,7 @@ class EtcdRequestGenerator:
         encoding='utf-8',
     ):
         encoded_key = key.encode(encoding)
-        range_end = increment_last_byte(encoded_key, encoding)
+        range_end = increment_last_byte(encoded_key)
         return rpc_pb2.RangeRequest(
             key=encoded_key,
             range_end=range_end,
@@ -405,7 +405,7 @@ class EtcdRequestGenerator:
     ):
         # TODO: Implement prev_kv response
         encoded_key = key.encode(encoding)
-        range_end = increment_last_byte(encoded_key, encoding)
+        range_end = increment_last_byte(encoded_key)
         return rpc_pb2.DeleteRangeRequest(
             key=encoded_key,
             range_end=range_end,
@@ -455,7 +455,7 @@ class EtcdRequestGenerator:
         encoding='utf-8',
     ):
         encoded_key = key.encode(encoding)
-        range_end = increment_last_byte(encoded_key, encoding)
+        range_end = increment_last_byte(encoded_key)
         return rpc_pb2.RangeRequest(
             key=encoded_key,
             range_end=range_end,
@@ -1300,7 +1300,7 @@ class EtcdCommunicator:
             encoding = self.encoding
 
         encoded_key = key.encode(encoding)
-        range_end = increment_last_byte(encoded_key, encoding)
+        range_end = increment_last_byte(encoded_key)
         return self._watch_impl(
             key.encode(encoding), encoding,
             ready_event=ready_event, filters=filters, prev_kv=prev_kv,
@@ -1661,13 +1661,8 @@ class EtcdLockManager:
         return False
 
 
-def increment_last_byte(key, encoding="utf-8"):
-    if type(key) is str:
-        byte_string = key.encode(encoding)
-    else:
-        byte_string = key
-
-    s = bytearray(byte_string)
+def increment_last_byte(encoded_key):
+    s = bytearray(encoded_key)
     for i in range(len(s) - 1, -1, -1):
         if s[i] < 0xff:
             s[i] += 1


### PR DESCRIPTION
### Issue 

We are adding +1 to the last byte excluding `/`, because of this, we are not receiving events.  Escpecially when you set the persmission based on the path like below.

role permission
```
etcdctl role grant-permission clientx --prefix=true readwrite app_data/clients/clientx2/
```

watch prefix for `app_data/clients/clientx2/` becomes  `b'app_data/clients/clientx3/'` but it supposed to be `b'app_data/clients/clientx30'` (As slash is part of the key, we shall add +1 to the slash)

# Fix
As per etcd3 spec https://etcd.io/docs/v3.3/learning/api/#:~:text=revision%20was%20committed.-,Key%20ranges,-The%20etcd3%20data

> By convention, ranges for a request are denoted by the fields key and range_end. The key field is the first key of the range and should be non-empty. The range_end is the key following the last key of the range. If range_end is not given or empty, the range is defined to contain only the key argument. If range_end is key plus one (e.g., “aa”+1 == “ab”, “a\xff”+1 == “b”), then the range represents all keys prefixed with key. If both key and range_end are ‘\0’, then range represents all keys. If range_end is ‘\0’, the range is all keys greater than or equal to the key argument.

### Some implementations

https://github.com/etcd-io/etcd/blob/main/client/v3/op.go#L376
https://github.com/gaopeiliang/aioetcd3/blob/4709a2a412cc81d47a8a262e569b4cd62a7659d4/aioetcd3/utils.py#L14


