### PR TITLE
chore(BA-1144): Support Python 3.13

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -6,11 +6,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: "pip"
           cache-dependency-path: |
             setup.cfg
@@ -31,11 +31,11 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: "pip"
           cache-dependency-path: |
             setup.cfg
@@ -57,11 +57,11 @@ jobs:
     runs-on: ubuntu-latest
     # runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: "pip"
           cache-dependency-path: |
             setup.cfg
@@ -110,11 +110,11 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: "pip"
           cache-dependency-path: |
             setup.cfg

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -76,7 +76,7 @@ jobs:
           docker run -d -p 2379:2379 -p 2380:2380 \
            -v /tmp/etcd:/etcd-data \
            --name backendai-etcd \
-           quay.io/coreos/etcd:v3.4.1 \
+           quay.io/coreos/etcd:v3.5.21 \
            /usr/local/bin/etcd \
            --name backendai-etcd \
            --data-dir /etcd-data \

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ setup_requires =
     setuptools>=70.0
     wheel>=0.45.1
 install_requires =
-    protobuf~=6.30.2
+    protobuf~=5.29.4
     grpcio==1.71.0
     grpcio-tools==1.71.0
 zip_safe = false

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,9 +14,9 @@ classifiers =
     Intended Audience :: Developers
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Operating System :: POSIX
     Operating System :: MacOS :: MacOS X
     Topic :: Software Development
@@ -29,33 +29,33 @@ project_urls =
 package_dir =
     = src
 packages = find_namespace:
-python_requires = >=3.10
+python_requires = >=3.11
 setup_requires =
-    setuptools>=51.1.1
-    wheel>=0.36.2
+    setuptools>=70.0
+    wheel>=0.45.1
 install_requires =
-    protobuf~=4.25.3
-    grpcio==1.62.2
-    grpcio-tools==1.62.2
+    protobuf~=6.30.2
+    grpcio==1.71.0
+    grpcio-tools==1.71.0
 zip_safe = false
 include_package_data = true
 
 [options.extras_require]
 build =
-    wheel>=0.36.2
-    twine>=3.4.1
+    wheel>=0.45.1
+    twine>=6.1.0
 test =
-    pytest~=6.2.5
-    pytest-asyncio~=0.16.0
-    pytest-cov>=2.11
-    pytest-mock>=3.5.0
+    pytest~=8.3.5
+    pytest-asyncio~=0.26.0
+    pytest-cov>=6.1.1
+    pytest-mock>=3.14.0
     codecov
 dev =
 lint =
-    flake8>=4.0.1
-    flake8-commas>=2.1
+    flake8>=7.2.0
+    flake8-commas>=4.0
 typecheck =
-    mypy>=1.4.1
+    mypy>=1.15.0
     types-protobuf
     types-setuptools
 

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -12,20 +12,20 @@ async def test_lock(etcd: EtcdClient):
     queue: Queue[int] = Queue()
 
     async def _lock_task_1(queue: Queue[int]):
-        global lock_1_entered
+        # global lock_1_entered
         async with etcd.with_lock('/test/locka'):
             queue.put(1)
             await asyncio.sleep(10)
 
     async def _lock_task_2(queue: Queue[int]):
-        global lock_2_entered
+        # global lock_2_entered
         await asyncio.sleep(3)
         async with etcd.with_lock('/test/locka'):
             queue.put(2)
             await asyncio.sleep(10)
 
     async def _lock_task_3(queue: Queue[int]):
-        global lock_3_entered
+        # global lock_3_entered
         await asyncio.sleep(3)
         async with etcd.with_lock('/test/lockb'):
             queue.put(3)


### PR DESCRIPTION
resolves lablup/backend.ai#4150 (BA-1144)

Although we no longer actively maintain this library as preference to [etcd-client-py](https://github.com/lablup/etcd-client-py), we have to update for Python 3.13 to avoid dependency issues in the Backend.AI's main mono-repo.